### PR TITLE
provide access to underlying strings

### DIFF
--- a/include/dictionary.hpp
+++ b/include/dictionary.hpp
@@ -102,7 +102,9 @@ struct dictionary {
         visitor.visit(m_skew_index);
         visitor.visit(m_weights);
     }
-
+    
+    const pthash::bit_vector& strings() const { return m_buckets.strings; }
+    
 private:
     uint64_t m_size;
     uint64_t m_seed;


### PR DESCRIPTION
For several reasons, it would be very useful to have access to the underlying strings / unitigs / simplitigs / eulertigs / matchtigs / tiles ( any other names ;P) underlying the dictionary.  This simply adds a function that returns a const reference to the underlying `bit_vector` that encodes the strings.