### PR TITLE
Partitioned phf

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are interested in a **membership-only** version of SSHash, have a look at
 #### Table of contents
 * [Compiling the Code](#compiling-the-code)
 * [Dependencies](#dependencies)
-* [Tools](#tools)
+* [Tools and Usage](#tools-and-usage)
 * [Examples](#Examples)
 * [Input Files](#input-files)
 * [Benchmarks](#benchmarks)
@@ -95,8 +95,8 @@ if you are on Linux/Ubuntu, or
 
 if you have a Mac.
 
-Tools
------
+Tools and Usage
+---------------
 
 There is one executable called `sshash` after the compilation, which can be used to run a tool.
 Run `./sshash` as follows to see a list of available tools.
@@ -114,14 +114,19 @@ Run `./sshash` as follows to see a list of available tools.
       permute                permute a weighted input file
       compute-statistics     compute index statistics
 
+For large-scale indexing, it could be necessary to increase the number of file descriptors that can be opened simultaneously:
+
+	ulimit -n 2048
+
 Examples
 --------
 
 For the examples, we are going to use some collections
 of *stitched unitigs* from the directory `../data/unitigs_stitched`.
-The value of k used during the formation of the unitigs
+
+**Important note:** The value of k used during the formation of the unitigs
 is indicated in the name of each file and the dictionaries
-should be built with that value as well to ensure correctness.
+**must** be built with that value as well to ensure correctness.
 
 For example, `data/unitigs_stitched/ecoli4_k31_ust.fa.gz` indicates the value k = 31, whereas `data/unitigs_stitched/se.ust.k63.fa.gz` indicates the value k = 63.
 

--- a/include/buckets.hpp
+++ b/include/buckets.hpp
@@ -259,9 +259,9 @@ struct buckets {
 
 private:
     bool is_valid(lookup_result res) const {
-        return (res.contig_size != constants::invalid_uint32 and
+        return (res.contig_size != constants::invalid_uint64 and
                 res.kmer_id_in_contig < res.contig_size) and
-               (res.contig_id != constants::invalid_uint32 or res.contig_id < pieces.size());
+               (res.contig_id != constants::invalid_uint64 or res.contig_id < pieces.size());
     }
 };
 

--- a/include/builder/build_index.hpp
+++ b/include/builder/build_index.hpp
@@ -5,15 +5,15 @@
 
 namespace sshash {
 
-#pragma pack(push, 4)
+
 struct bucket_pair {
-    bucket_pair(uint64_t id, uint32_t size) : id(id), size(size) {}
+    bucket_pair(uint64_t id, uint64_t size) : id(id), size(size) {}
     uint64_t id;
-    uint32_t size;
+    uint64_t size;
 
     bool operator>(bucket_pair other) const { return id > other.id; }
 };
-#pragma pack(pop)
+
 
 struct bucket_pairs_iterator : std::forward_iterator_tag {
     bucket_pairs_iterator(bucket_pair const* begin, bucket_pair const* end)
@@ -52,7 +52,7 @@ struct bucket_pairs {
         std::cout << "m_buffer_size " << m_buffer_size << std::endl;
     }
 
-    void emplace_back(uint64_t id, uint32_t size) {
+    void emplace_back(uint64_t id, uint64_t size) {
         if (m_buffer.size() == m_buffer_size) sort_and_flush();
         m_buffer.emplace_back(id, size);
     }
@@ -174,7 +174,7 @@ buckets_statistics build_index(parse_data& data, minimizers const& m_minimizers,
     uint64_t num_singletons = 0;
     for (minimizers_tuples_iterator it(input.data(), input.data() + input.size()); it.has_next();
          it.next()) {
-        uint32_t list_size = it.list().size();
+        uint64_t list_size = it.list().size();
         assert(list_size > 0);
         if (list_size != 1) {
             uint64_t bucket_id = m_minimizers.lookup(it.minimizer());

--- a/include/builder/build_skew_index.hpp
+++ b/include/builder/build_skew_index.hpp
@@ -129,7 +129,7 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
         pthash::build_configuration mphf_config;
         mphf_config.c = build_config.c;
         mphf_config.alpha = 0.94;
-        mphf_config.seed = 1234567890;  // my favourite seed
+        mphf_config.seed = util::get_seed_for_hash_function(build_config);
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
         mphf_config.num_threads = std::thread::hardware_concurrency();

--- a/include/builder/build_skew_index.hpp
+++ b/include/builder/build_skew_index.hpp
@@ -142,7 +142,7 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
 
         /* tmp storage for keys and super_kmer_ids ******/
         std::vector<kmer_t> keys_in_partition;
-        std::vector<uint32_t> super_kmer_ids_in_partition;
+        std::vector<uint64_t> super_kmer_ids_in_partition;
         keys_in_partition.reserve(num_kmers_in_partition[partition_id]);
         super_kmer_ids_in_partition.reserve(num_kmers_in_partition[partition_id]);
         pthash::compact_vector::builder cvb_positions;
@@ -183,7 +183,7 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
                 for (uint64_t i = 0; i != keys_in_partition.size(); ++i) {
                     kmer_t kmer = keys_in_partition[i];
                     uint64_t pos = mphf(kmer);
-                    uint32_t super_kmer_id = super_kmer_ids_in_partition[i];
+                    uint64_t super_kmer_id = super_kmer_ids_in_partition[i];
                     cvb_positions.set(pos, super_kmer_id);
                 }
                 auto& positions = m_skew_index.positions[partition_id];

--- a/include/builder/file_merging_iterator.hpp
+++ b/include/builder/file_merging_iterator.hpp
@@ -38,15 +38,15 @@ struct file_merging_iterator {
 
 private:
     std::vector<FileIterator> m_iterators;
-    std::vector<uint32_t> m_idx_heap;
+    std::vector<uint64_t> m_idx_heap;
     std::vector<mm::file_source<uint8_t>> m_mm_files;
 
-    std::function<bool(uint32_t, uint32_t)> heap_idx_comparator = [&](uint32_t i, uint32_t j) {
+    std::function<bool(uint64_t, uint64_t)> heap_idx_comparator = [&](uint64_t i, uint64_t j) {
         return (*m_iterators[i]) > (*m_iterators[j]);
     };
 
     void advance_heap_head() {
-        uint32_t idx = m_idx_heap.front();
+        uint64_t idx = m_idx_heap.front();
         m_iterators[idx].next();
         if (m_iterators[idx].has_next()) {  // percolate down the head
             uint64_t pos = 0;

--- a/include/builder/util.hpp
+++ b/include/builder/util.hpp
@@ -83,9 +83,6 @@ struct compact_string_pool {
                     throw std::runtime_error("contig_length " + std::to_string(contig_length) +
                                              " does not fit into 32 bits");
                 }
-                if (pieces.size() == 1ULL << 32) {
-                    throw std::runtime_error("num_contigs must be less than 2^32");
-                }
             }
         }
     };

--- a/include/builder/util.hpp
+++ b/include/builder/util.hpp
@@ -45,7 +45,6 @@ struct compact_string_pool {
                 prefix = k - 1;
             } else {
                 /* otherwise, start a new piece */
-                check_contig_size();
                 pieces.push_back(bvb_strings.size() / 2);
             }
             for (uint64_t i = prefix; i != size; ++i) {
@@ -58,7 +57,6 @@ struct compact_string_pool {
         void finalize() {
             /* So pieces will be of size p+1, where p is the number of DNA sequences
                in the input file. */
-            check_contig_size();
             pieces.push_back(bvb_strings.size() / 2);
             assert(pieces.front() == 0);
 
@@ -72,19 +70,6 @@ struct compact_string_pool {
         uint64_t num_super_kmers;
         std::vector<uint64_t> pieces;
         pthash::bit_vector_builder bvb_strings;
-
-    private:
-        void check_contig_size() const {
-            /* Support a max of 2^32-1 contigs, or "pieces", whose
-               max length must also be < 2^32. */
-            if (!pieces.empty()) {
-                uint64_t contig_length = bvb_strings.size() / 2 - pieces.back();
-                if (contig_length >= 1ULL << 32) {
-                    throw std::runtime_error("contig_length " + std::to_string(contig_length) +
-                                             " does not fit into 32 bits");
-                }
-            }
-        }
     };
 
     uint64_t num_bits() const { return strings.size(); }

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -14,7 +14,6 @@ constexpr uint64_t max_m = 31;
 
 // constexpr kmer_t invalid_uint_kmer = kmer_t(-1);
 constexpr uint64_t invalid_uint64 = uint64_t(-1);
-constexpr uint32_t invalid_uint32 = uint32_t(-1);
 
 constexpr uint64_t seed = 1;
 constexpr double c = 3.0;  // for PTHash

--- a/include/cover/even_frequency_weights.hpp
+++ b/include/cover/even_frequency_weights.hpp
@@ -11,14 +11,14 @@ struct even_frequency_weights {
     even_frequency_weights() {}
 
     struct wf {
-        uint32_t w, f;
+        uint64_t w, f;
     };
     struct range {
-        uint32_t b, e;
+        uint64_t b, e;
     };
 
-    void build(std::unordered_map<uint32_t, uint32_t> const& freq) {
-        uint32_t num_distinct_weights = freq.size();
+    void build(std::unordered_map<uint64_t, uint64_t> const& freq) {
+        uint64_t num_distinct_weights = freq.size();
         T.reserve(num_distinct_weights);
         P.reserve(num_distinct_weights);
         R[0] = {0, 0};
@@ -29,11 +29,11 @@ struct even_frequency_weights {
 
         std::sort(T.begin(), T.end(), [](auto const& x, auto const& y) { return x.f < y.f; });
 
-        uint32_t f = T.front().f;
+        uint64_t f = T.front().f;
         range r;
         r.b = 0;
         r.e = 0;
-        for (uint32_t i = 0; i != T.size(); ++i) {
+        for (uint64_t i = 0; i != T.size(); ++i) {
             P[T[i].w] = i;
             if (T[i].f == f) {
                 r.e += 1;
@@ -61,30 +61,30 @@ struct even_frequency_weights {
 
     bool has_next() { return R[0].e < T.size(); }
 
-    uint32_t min() {
+    uint64_t min() {
         assert(has_next());
-        uint32_t w = T[R[0].e].w;
+        uint64_t w = T[R[0].e].w;
         decrease_freq(w);
         return w;
     }
 
-    void decrease_freq(uint32_t w) {
-        uint32_t i = R[0].e;  // pos of weight of minimum frequency
+    void decrease_freq(uint64_t w) {
+        uint64_t i = R[0].e;  // pos of weight of minimum frequency
 
         if (w != T[i].w) {
             if (P.find(w) == P.cend()) return;
-            uint32_t j = P[w];
+            uint64_t j = P[w];
             assert(T[j].w == w);
-            uint32_t f = T[j].f;
+            uint64_t f = T[j].f;
             i = R[f].b;
-            uint32_t v = T[i].w;
+            uint64_t v = T[i].w;
             std::swap(T[j], T[i]);
             P[w] = i;
             P[v] = j;
             assert(T[i].f == f);
         }
 
-        uint32_t& f = T[i].f;
+        uint64_t& f = T[i].f;
         assert(f >= 2);
         if (R.find(f - 2) != R.cend()) {
             R[f - 2].e += 1;
@@ -97,8 +97,8 @@ struct even_frequency_weights {
     }
 
     std::vector<wf> T;                         // array of pairs (weight,frequency)
-    std::unordered_map<uint32_t, range> R;     // frequency --> [b,e) (range into T)
-    std::unordered_map<uint32_t, uint32_t> P;  // weight --> p (position into T)
+    std::unordered_map<uint64_t, range> R;     // frequency --> [b,e) (range into T)
+    std::unordered_map<uint64_t, uint64_t> P;  // weight --> p (position into T)
 };
 
 }  // namespace sshash

--- a/include/cover/node.hpp
+++ b/include/cover/node.hpp
@@ -9,30 +9,30 @@ namespace sshash {
 
 struct node {
     node()
-        : id(constants::invalid_uint32)
-        , front(constants::invalid_uint32)
-        , back(constants::invalid_uint32)
+        : id(constants::invalid_uint64)
+        , front(constants::invalid_uint64)
+        , back(constants::invalid_uint64)
         , sign(true)
-        , chain_id(constants::invalid_uint32)
-        , left(constants::invalid_uint32)
-        , right(constants::invalid_uint32) {}
+        , chain_id(constants::invalid_uint64)
+        , left(constants::invalid_uint64)
+        , right(constants::invalid_uint64) {}
 
-    node(uint32_t i, uint32_t f, uint32_t b, bool s = true)
+    node(uint64_t i, uint64_t f, uint64_t b, bool s = true)
         : id(i)
         , front(f)
         , back(b)
         , sign(s)
-        , chain_id(constants::invalid_uint32)
-        , left(constants::invalid_uint32)
-        , right(constants::invalid_uint32) {}
+        , chain_id(constants::invalid_uint64)
+        , left(constants::invalid_uint64)
+        , right(constants::invalid_uint64) {}
 
-    uint32_t id, front, back;
+    uint64_t id, front, back;
 
     bool sign;  // '+' --> forward
                 // '-' --> backward
 
-    uint32_t chain_id;
-    uint32_t left, right;
+    uint64_t chain_id;
+    uint64_t left, right;
 
     void print() const {
         std::cout << id << ":[" << front << "," << back << "," << (sign ? '+' : '-') << "]"

--- a/include/cover/parse_file.hpp
+++ b/include/cover/parse_file.hpp
@@ -29,7 +29,7 @@ void parse_file(std::istream& is, permute_data& data, build_configuration const&
     data.num_sequences = 0;
 
     /* count number of distinct weights */
-    std::unordered_set<uint32_t> distinct_weights;
+    std::unordered_set<uint64_t> distinct_weights;
 
     auto parse_header = [&]() {
         if (sequence.empty()) return;
@@ -186,7 +186,7 @@ void reverse_header(std::string const& input, std::string& output, uint64_t k) {
     i = j + 6;  // skip ' ab:Z:'
     output.append(input.data(), input.data() + i);
 
-    std::vector<uint32_t> weights;
+    std::vector<uint64_t> weights;
     weights.reserve(seq_len - k + 1);
     for (uint64_t j = 0; j != seq_len - k + 1; ++j) {
         uint64_t weight = std::strtoull(input.data() + i, nullptr, 10);
@@ -283,12 +283,12 @@ void permute_and_write(std::istream& is, std::string const& output_filename,
         std::cout << "files to merge = " << num_files_to_merge << std::endl;
 
         std::vector<lines_iterator> iterators;
-        std::vector<uint32_t> idx_heap;
+        std::vector<uint64_t> idx_heap;
         iterators.reserve(num_files_to_merge);
         idx_heap.reserve(num_files_to_merge);
         std::vector<mm::file_source<uint8_t>> mm_files(num_files_to_merge);
 
-        auto heap_idx_comparator = [&](uint32_t i, uint32_t j) {
+        auto heap_idx_comparator = [&](uint64_t i, uint64_t j) {
             assert(iterators[i].header().front() == '>');
             assert(iterators[j].header().front() == '>');
             uint64_t seq_id_x = std::strtoull(iterators[i].header().data() + 1, nullptr, 10);

--- a/include/dictionary.cpp
+++ b/include/dictionary.cpp
@@ -10,7 +10,7 @@ lookup_result dictionary::lookup_uint_regular_parsing(kmer_t uint_kmer) const {
 
     auto [begin, end] = m_buckets.locate_bucket(bucket_id);
     uint64_t num_super_kmers_in_bucket = end - begin;
-    uint64_t log2_bucket_size = util::ceil_log2_uint32(num_super_kmers_in_bucket);
+    uint64_t log2_bucket_size = util::ceil_log2_uint64(num_super_kmers_in_bucket);
     if (log2_bucket_size > m_skew_index.min_log2) {
         uint64_t pos = m_skew_index.lookup(uint_kmer, log2_bucket_size);
         /* It must hold pos < num_super_kmers_in_bucket for the kmer to exist. */
@@ -35,7 +35,7 @@ lookup_result dictionary::lookup_uint_canonical_parsing(kmer_t uint_kmer) const 
 
     auto [begin, end] = m_buckets.locate_bucket(bucket_id);
     uint64_t num_super_kmers_in_bucket = end - begin;
-    uint64_t log2_bucket_size = util::ceil_log2_uint32(num_super_kmers_in_bucket);
+    uint64_t log2_bucket_size = util::ceil_log2_uint64(num_super_kmers_in_bucket);
     if (log2_bucket_size > m_skew_index.min_log2) {
         uint64_t pos = m_skew_index.lookup(uint_kmer, log2_bucket_size);
         if (pos < num_super_kmers_in_bucket) {

--- a/include/ef_sequence.hpp
+++ b/include/ef_sequence.hpp
@@ -15,7 +15,7 @@ struct ef_sequence {
         if (n == 0) return;
         m_universe = u;
 
-        uint64_t l = uint64_t((n && u / n) ? pthash::util::msb(u / n) : 0);
+        uint64_t l = uint64_t((n && u / n) ? pthash::util::msb(u / n) : 0); // Do we need msb_uint64 here?
         pthash::bit_vector_builder bvb_high_bits(n + (u >> l) + 1);
         pthash::compact_vector::builder cv_builder_low_bits(n, l);
 

--- a/include/ef_sequence.hpp
+++ b/include/ef_sequence.hpp
@@ -15,7 +15,7 @@ struct ef_sequence {
         if (n == 0) return;
         m_universe = u;
 
-        uint64_t l = uint64_t((n && u / n) ? pthash::util::msb(u / n) : 0); // Do we need msb_uint64 here?
+        uint64_t l = uint64_t((n && u / n) ? pthash::util::msb(u / n) : 0);
         pthash::bit_vector_builder bvb_high_bits(n + (u >> l) + 1);
         pthash::compact_vector::builder cv_builder_low_bits(n, l);
 

--- a/include/gz/zip_stream.cpp
+++ b/include/gz/zip_stream.cpp
@@ -138,8 +138,8 @@ uint32_t basic_zip_streambuf<CharT, Traits>::get_crc() const {
 }
 
 template <typename CharT, typename Traits>
-uint32_t basic_zip_streambuf<CharT, Traits>::get_in_size() const {
-    return static_cast<uint32_t>(zip_stream_.total_in);
+uint64_t basic_zip_streambuf<CharT, Traits>::get_in_size() const {
+    return static_cast<uint64_t>(zip_stream_.total_in);
 }
 
 template <typename CharT, typename Traits>
@@ -266,8 +266,8 @@ unsigned long basic_unzip_streambuf<CharT, Traits>::get_out_size() const {
 }
 
 template <typename CharT, typename Traits>
-uint32_t basic_unzip_streambuf<CharT, Traits>::get_in_size() const {
-    return static_cast<uint32_t>(zip_stream_.total_in);
+uint64_t basic_unzip_streambuf<CharT, Traits>::get_in_size() const {
+    return static_cast<uint64_t>(zip_stream_.total_in);
 }
 
 template <typename CharT, typename Traits>
@@ -394,7 +394,7 @@ basic_zip_ostream<CharT, Traits>& basic_zip_ostream<CharT, Traits>::add_footer()
         crc >>= 8;
     }
 
-    uint32_t length = this->get_in_size();
+    uint64_t length = this->get_in_size();
     for (int m = 0; m < 4; ++m) {
         this->get_ostream().put(static_cast<char>(length & 0xff));
         length >>= 8;

--- a/include/gz/zip_stream.cpp
+++ b/include/gz/zip_stream.cpp
@@ -514,7 +514,7 @@ void basic_zip_istream<CharT, Traits>::read_footer() {
 
         gzip_data_size_ = 0;
         for (int n = 0; n < 4; ++n)
-            gzip_data_size_ += (static_cast<uint32_t>(this->get_istream().get()) & 0xff) << (8 * n);
+            gzip_data_size_ += (static_cast<uint64_t>(this->get_istream().get()) & 0xff) << (8 * n);
     }
 }
 

--- a/include/gz/zip_stream.hpp
+++ b/include/gz/zip_stream.hpp
@@ -121,7 +121,7 @@ public:
     uint32_t get_crc() const;
 
     //! returns the size (bytes) of the input data compressed so far.
-    uint32_t get_in_size() const;
+    uint64_t get_in_size() const;
 
     //! returns the size (bytes) of the compressed data so far.
     unsigned long get_out_size() const;
@@ -183,7 +183,7 @@ public:
     unsigned long get_out_size() const;
 
     //! returns the number of read compressed bytes
-    uint32_t get_in_size() const;
+    uint64_t get_in_size() const;
 
 private:
     void put_back_from_zip_stream();

--- a/include/gz/zip_stream.hpp
+++ b/include/gz/zip_stream.hpp
@@ -283,7 +283,7 @@ protected:
 
     bool is_gzip_;
     uint32_t gzip_crc_;
-    uint32_t gzip_data_size_;
+    uint64_t gzip_data_size_;
 };
 
 /******************************************************************************/

--- a/include/minimizers.hpp
+++ b/include/minimizers.hpp
@@ -10,7 +10,7 @@ struct minimizers {
         pthash::build_configuration mphf_config;
         mphf_config.c = 6.0;
         mphf_config.alpha = 0.94;
-        mphf_config.seed = 1234567890;  // my favourite seed
+        mphf_config.seed = util::get_seed_for_hash_function(build_config);
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
         mphf_config.num_threads = std::thread::hardware_concurrency();

--- a/include/query/streaming_query_canonical_parsing.hpp
+++ b/include/query/streaming_query_canonical_parsing.hpp
@@ -138,7 +138,7 @@ private:
         bool check_minimizer = !same_minimizer();
         if (!m_dict->m_skew_index.empty()) {
             uint64_t num_super_kmers_in_bucket = m_end - m_begin;
-            uint64_t log2_bucket_size = util::ceil_log2_uint32(num_super_kmers_in_bucket);
+            uint64_t log2_bucket_size = util::ceil_log2_uint64(num_super_kmers_in_bucket);
             if (log2_bucket_size > (m_dict->m_skew_index).min_log2) {
                 uint64_t p = m_dict->m_skew_index.lookup(m_kmer, log2_bucket_size);
                 if (p < num_super_kmers_in_bucket) {

--- a/include/query/streaming_query_regular_parsing.hpp
+++ b/include/query/streaming_query_regular_parsing.hpp
@@ -179,7 +179,7 @@ private:
         bool check_minimizer = !same_minimizer();
         if (!m_dict->m_skew_index.empty()) {
             uint64_t num_super_kmers_in_bucket = m_end - m_begin;
-            uint64_t log2_bucket_size = util::ceil_log2_uint32(num_super_kmers_in_bucket);
+            uint64_t log2_bucket_size = util::ceil_log2_uint64(num_super_kmers_in_bucket);
             if (log2_bucket_size > (m_dict->m_skew_index).min_log2) {
                 uint64_t p = m_dict->m_skew_index.lookup(m_kmer, log2_bucket_size);
                 if (p < num_super_kmers_in_bucket) {
@@ -197,7 +197,7 @@ private:
         bool check_minimizer = !same_minimizer_rc();
         if (!m_dict->m_skew_index.empty()) {
             uint64_t num_super_kmers_in_bucket = m_end - m_begin;
-            uint64_t log2_bucket_size = util::ceil_log2_uint32(num_super_kmers_in_bucket);
+            uint64_t log2_bucket_size = util::ceil_log2_uint64(num_super_kmers_in_bucket);
             if (log2_bucket_size > (m_dict->m_skew_index).min_log2) {
                 uint64_t p = m_dict->m_skew_index.lookup(m_kmer_rc, log2_bucket_size);
                 if (p < num_super_kmers_in_bucket) {

--- a/include/skew_index.hpp
+++ b/include/skew_index.hpp
@@ -53,7 +53,7 @@ struct skew_index {
 
     uint16_t min_log2;
     uint16_t max_log2;
-    uint32_t log2_max_num_super_kmers_in_bucket;
+    uint64_t log2_max_num_super_kmers_in_bucket;
     std::vector<kmers_pthash_type> mphfs;
     std::vector<pthash::compact_vector> positions;
 };

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -114,6 +114,11 @@ struct build_configuration {
 
 namespace util {
 
+static uint64_t get_seed_for_hash_function(build_configuration const& build_config) {
+    static const uint64_t my_favourite_seed = 1234567890;
+    return build_config.seed != my_favourite_seed ? my_favourite_seed : ~my_favourite_seed;
+}
+
 /* return the position of the most significant bit */
 static inline uint32_t msb(uint32_t x) {
     assert(x > 0);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -21,15 +21,15 @@ struct streaming_query_report {
 struct lookup_result {
     lookup_result()
         : kmer_id(constants::invalid_uint64)
-        , kmer_id_in_contig(constants::invalid_uint32)
+        , kmer_id_in_contig(constants::invalid_uint64)
         , kmer_orientation(constants::forward_orientation)
-        , contig_id(constants::invalid_uint32)
+        , contig_id(constants::invalid_uint64)
         , contig_size(constants::invalid_uint32) {}
     uint64_t kmer_id;            // "absolute" kmer-id
-    uint32_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
-    uint32_t kmer_orientation;
-    uint32_t contig_id;
+    uint64_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
+    uint64_t contig_id;
     uint32_t contig_size;
+    uint32_t kmer_orientation;
 };
 
 struct neighbourhood {

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -131,7 +131,7 @@ static inline uint64_t msb_uint64(uint64_t x) {
 }
 
 static inline uint32_t ceil_log2_uint32(uint32_t x) { return (x > 1) ? msb_uint32(x - 1) + 1 : 0; }
-static inline uint64_t ceil_log2_uint64(uint64_t x) { return (x > 1) ? msb_uint64(x - 1) + 1 : 0;
+static inline uint64_t ceil_log2_uint64(uint64_t x) { return (x > 1) ? msb_uint64(x - 1) + 1 : 0; }
 
 
 [[maybe_unused]] static bool ends_with(std::string const& str, std::string const& pattern) {

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -24,11 +24,11 @@ struct lookup_result {
         , kmer_id_in_contig(constants::invalid_uint64)
         , kmer_orientation(constants::forward_orientation)
         , contig_id(constants::invalid_uint64)
-        , contig_size(constants::invalid_uint32) {}
+        , contig_size(constants::invalid_uint64) {}
     uint64_t kmer_id;            // "absolute" kmer-id
     uint64_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
     uint64_t contig_id;
-    uint32_t contig_size;
+    uint64_t contig_size;
     uint32_t kmer_orientation;
 };
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -27,9 +27,9 @@ struct lookup_result {
         , contig_size(constants::invalid_uint64) {}
     uint64_t kmer_id;            // "absolute" kmer-id
     uint64_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
+    uint32_t kmer_orientation;
     uint64_t contig_id;
     uint64_t contig_size;
-    uint32_t kmer_orientation;
 };
 
 struct neighbourhood {

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -120,12 +120,19 @@ static uint64_t get_seed_for_hash_function(build_configuration const& build_conf
 }
 
 /* return the position of the most significant bit */
-static inline uint32_t msb(uint32_t x) {
+static inline uint32_t msb_uint32(uint32_t x) {
     assert(x > 0);
     return 31 - __builtin_clz(x);
 }
 
-static inline uint32_t ceil_log2_uint32(uint32_t x) { return (x > 1) ? msb(x - 1) + 1 : 0; }
+static inline uint64_t msb_uint64(uint64_t x) {
+    assert(x > 0);
+    return 63 - __builtin_clzll(x);
+}
+
+static inline uint32_t ceil_log2_uint32(uint32_t x) { return (x > 1) ? msb_uint32(x - 1) + 1 : 0; }
+static inline uint64_t ceil_log2_uint64(uint64_t x) { return (x > 1) ? msb_uint64(x - 1) + 1 : 0;
+
 
 [[maybe_unused]] static bool ends_with(std::string const& str, std::string const& pattern) {
     if (pattern.size() > str.size()) return false;

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -27,7 +27,7 @@ struct lookup_result {
         , contig_size(constants::invalid_uint64) {}
     uint64_t kmer_id;            // "absolute" kmer-id
     uint64_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
-    uint32_t kmer_orientation;
+    uint64_t kmer_orientation;
     uint64_t contig_id;
     uint64_t contig_size;
 };
@@ -120,17 +120,11 @@ static uint64_t get_seed_for_hash_function(build_configuration const& build_conf
 }
 
 /* return the position of the most significant bit */
-static inline uint32_t msb_uint32(uint32_t x) {
-    assert(x > 0);
-    return 31 - __builtin_clz(x);
-}
-
 static inline uint64_t msb_uint64(uint64_t x) {
     assert(x > 0);
     return 63 - __builtin_clzll(x);
 }
 
-static inline uint32_t ceil_log2_uint32(uint32_t x) { return (x > 1) ? msb_uint32(x - 1) + 1 : 0; }
 static inline uint64_t ceil_log2_uint64(uint64_t x) { return (x > 1) ? msb_uint64(x - 1) + 1 : 0; }
 
 


### PR DESCRIPTION
I think we can already add this. 

The lookups were tested with https://github.com/rickbeeloo/UniqueMers, with `2^32` unique 17-mer lookup being correct according to the sshash `--check` (`UniqueMers kmers.fasta 17 4294967296 0`). 

I just added "tail" to the linked repo to add random sequences after each kmer allowing for the navigational queries to be tested, but instead of re-running sshash again for this I think we can better do Fulgor immediately. 
