### PR TITLE
Include cstdint in gz

### DIFF
--- a/include/gz/zip_stream.hpp
+++ b/include/gz/zip_stream.hpp
@@ -64,6 +64,7 @@ zran.c
 #include <ostream>
 #include <streambuf>
 #include <vector>
+#include <cstdint>
 
 //! default gzip buffer size, change this to suite your needs
 static const size_t zstream_default_buffer_size = 4096;


### PR DESCRIPTION
On some setups, I get a bunch of errors that look like

```sh
In file included from /home/adamant/sshash-jermp/include/gz/zip_stream.cpp:1:
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:121:5: error: ‘uint32_t’ does not name a type
  121 |     uint32_t get_crc() const;
      |     ^~~~~~~~
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:67:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   66 | #include <vector>
  +++ |+#include <cstdint>
   67 | 
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:124:5: error: ‘uint32_t’ does not name a type
  124 |     uint32_t get_in_size() const;
      |     ^~~~~~~~
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:124:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:137:5: error: ‘uint32_t’ does not name a type
  137 |     uint32_t crc_;
      |     ^~~~~~~~
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:137:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/adamant/sshash-jermp/include/gz/zip_stream.hpp:180:5: error: ‘uint32_t’ does not name a type
  180 |     uint32_t get_crc() const;
      |     ^~~~~~~~
```

This include fixes it.