### PR TITLE
Partitioned phf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ if (UNIX)
 
 endif()
 
+include_directories(.) # all include paths relative to parent directory
+
 set(Z_LIB_SOURCES
   include/gz/zip_stream.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,13 @@ if (UNIX AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2 -msse4.2") # for hardware popcount and pdep
 endif()
 
+if (SSHASH_USE_MAX_KMER_LENGTH_63)
+  MESSAGE(STATUS "SSHash uses a maximum kmer length of 63")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSSHASH_USE_MAX_KMER_LENGTH_63")
+else()
+  MESSAGE(STATUS "SSHash uses a maximum kmer length of 31")
+endif()
+
 if (SSHASH_USE_TRADITIONAL_NUCLEOTIDE_ENCODING)
   MESSAGE(STATUS "SSHash maps {'A','a'}->0, {'C','c'}->1, {'G','g'}->2, and {'T','t'}->3")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSSHASH_USE_TRADITIONAL_NUCLEOTIDE_ENCODING")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are interested in a **membership-only** version of SSHash, have a look at
 #### Table of contents
 * [Compiling the Code](#compiling-the-code)
 * [Dependencies](#dependencies)
-* [Tools](#tools)
+* [Tools and Usage](#tools-and-usage)
 * [Examples](#Examples)
 * [Input Files](#input-files)
 * [Benchmarks](#benchmarks)
@@ -95,8 +95,8 @@ if you are on Linux/Ubuntu, or
 
 if you have a Mac.
 
-Tools
------
+Tools and Usage
+---------------
 
 There is one executable called `sshash` after the compilation, which can be used to run a tool.
 Run `./sshash` as follows to see a list of available tools.
@@ -114,14 +114,19 @@ Run `./sshash` as follows to see a list of available tools.
       permute                permute a weighted input file
       compute-statistics     compute index statistics
 
+For large-scale indexing, it could be necessary to increase the number of file descriptors that can be opened simultaneously:
+
+	ulimit -n 2048
+
 Examples
 --------
 
 For the examples, we are going to use some collections
 of *stitched unitigs* from the directory `../data/unitigs_stitched`.
-The value of k used during the formation of the unitigs
+
+**Important note:** The value of k used during the formation of the unitigs
 is indicated in the name of each file and the dictionaries
-should be built with that value as well to ensure correctness.
+**must** be built with that value as well to ensure correctness.
 
 For example, `data/unitigs_stitched/ecoli4_k31_ust.fa.gz` indicates the value k = 31, whereas `data/unitigs_stitched/se.ust.k63.fa.gz` indicates the value k = 63.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Examples
 --------
 
 For the examples, we are going to use some collections
-of *stitched unitigs* from the directory `../data/unitigs_stitched`.
+of *stitched unitigs* from the directory `data/unitigs_stitched`.
 
 **Important note:** The value of k used during the formation of the unitigs
 is indicated in the name of each file and the dictionaries
@@ -167,7 +167,7 @@ For example, `data/unitigs_stitched/ecoli4_k31_ust.fa.gz` indicates the value k 
 
 For all the examples below, we are going to use k = 31.
 
-(The subdirectory `../data/unitigs_stitched/with_weights` contains some files with k-mers' weights too.)
+(The directory `data/unitigs_stitched/with_weights` contains some files with k-mers' weights too.)
 
 In the section [Input Files](#input-files), we explain how
 such collections of stitched unitigs can be obtained from raw FASTA files.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ SSHash uses by default the following 2-bit encoding of nucleotides.
 	 C     67     01000.01.1 -> 01
 	 G     71     01000.11.1 -> 11
 	 T     84     01010.10.0 -> 10
-	
+
 	 a     97     01100.00.1 -> 00
 	 c     99     01100.01.1 -> 01
 	 g    103     01100.11.1 -> 11
@@ -97,7 +97,7 @@ If you want to use the "traditional" encoding
 	 C     67     01000011 -> 01
 	 G     71     01000111 -> 10
 	 T     84     01010100 -> 11
-	
+
 	 a     97     01100001 -> 00
 	 c     99     01100011 -> 01
 	 g    103     01100111 -> 10

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a compressed dictionary data structure for k-mers
 The data structure is described in the following papers:
 
 * [Sparse and Skew Hashing of K-Mers](https://doi.org/10.1093/bioinformatics/btac245) [1]
-* [On Weighted K-Mers Dictionaries](https://almob.biomedcentral.com/articles/10.1186/s13015-023-00226-2) [2,3]
+* [On Weighted K-Mer Dictionaries](https://almob.biomedcentral.com/articles/10.1186/s13015-023-00226-2) [2,3]
 
 **Please, cite these papers if you use SSHash.**
 
@@ -105,6 +105,12 @@ If you want to use the "traditional" encoding
 
 for compatibility issues with other software, then
 compile SSHash with the flag `-DSSHASH_USE_TRADITIONAL_NUCLEOTIDE_ENCODING=On`.
+
+### K-mer Length
+
+By default, SSHash uses a maximum k-mer length of 31.
+If you want to support k-mer lengths up to (and including) 63,
+compile the library with the flag `-DSSHASH_USE_MAX_KMER_LENGTH_63=On`.
 
 Dependencies
 ------------
@@ -374,6 +380,6 @@ Author
 References
 -----
 * [1] Giulio Ermanno Pibiri. [Sparse and Skew Hashing of K-Mers](https://doi.org/10.1093/bioinformatics/btac245). Bioinformatics. 2022.
-* [2] Giulio Ermanno Pibiri. [On Weighted K-Mers Dictionaries](https://drops.dagstuhl.de/opus/volltexte/2022/17043/). International Workshop on Algorithms in Bioinformatics (WABI). 2022.
-* [3] Giulio Ermanno Pibiri. [On Weighted K-Mers Dictionaries](https://almob.biomedcentral.com/articles/10.1186/s13015-023-00226-2). Algorithms for Molecular Biology (ALGOMB). 2023.
+* [2] Giulio Ermanno Pibiri. [On Weighted K-Mer Dictionaries](https://drops.dagstuhl.de/opus/volltexte/2022/17043/). International Workshop on Algorithms in Bioinformatics (WABI). 2022.
+* [3] Giulio Ermanno Pibiri. [On Weighted K-Mer Dictionaries](https://almob.biomedcentral.com/articles/10.1186/s13015-023-00226-2). Algorithms for Molecular Biology (ALGOMB). 2023.
 * [4] Schmidt, S., Khan, S., Alanko, J., Pibiri, G. E., and Tomescu, A. I. [Matchtigs: minimum plain text representation of k-mer sets](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-023-02968-z). Genome Biology 24, 136. 2023.

--- a/include/bit_vector_iterator.hpp
+++ b/include/bit_vector_iterator.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../external/pthash/include/encoders/bit_vector.hpp"
+#include "external/pthash/include/encoders/bit_vector.hpp"
 #include "util.hpp"
 
 namespace sshash {

--- a/include/buckets.hpp
+++ b/include/buckets.hpp
@@ -259,9 +259,9 @@ struct buckets {
 
 private:
     bool is_valid(lookup_result res) const {
-        return (res.contig_size != constants::invalid_uint32 and
+        return (res.contig_size != constants::invalid_uint64 and
                 res.kmer_id_in_contig < res.contig_size) and
-               (res.contig_id != constants::invalid_uint32 or res.contig_id < pieces.size());
+               (res.contig_id != constants::invalid_uint64 or res.contig_id < pieces.size());
     }
 };
 

--- a/include/builder/build.cpp
+++ b/include/builder/build.cpp
@@ -1,5 +1,5 @@
-#include "../dictionary.hpp"
-#include "../../external/pthash/external/essentials/include/essentials.hpp"
+#include "include/dictionary.hpp"
+#include "external/pthash/external/essentials/include/essentials.hpp"
 #include "util.hpp"
 
 /** build steps **/

--- a/include/builder/build_index.hpp
+++ b/include/builder/build_index.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "file_merging_iterator.hpp"
-#include "../buckets_statistics.hpp"
+#include "include/buckets_statistics.hpp"
 
 namespace sshash {
 

--- a/include/builder/build_skew_index.hpp
+++ b/include/builder/build_skew_index.hpp
@@ -132,10 +132,8 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
         mphf_config.seed = 1234567890;  // my favourite seed
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
-        mphf_config.num_threads = std::thread::hardware_concurrency() >= 8 ? 8 : 1;
-
-        std::cout << "building PTHash mphfs (with " << mphf_config.num_threads
-                  << " threads) and positions..." << std::endl;
+        mphf_config.num_threads = std::thread::hardware_concurrency();
+        mphf_config.num_partitions = 4 * mphf_config.num_threads;
 
         uint64_t partition_id = 0;
         uint64_t lower = 1ULL << min_log2_size;
@@ -160,8 +158,23 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
                 auto& mphf = m_skew_index.mphfs[partition_id];
                 assert(num_kmers_in_partition[partition_id] == keys_in_partition.size());
                 assert(num_kmers_in_partition[partition_id] == super_kmer_ids_in_partition.size());
+
+                if (keys_in_partition.size() / mphf_config.num_partitions <
+                    pthash::constants::min_partition_size) {
+                    mphf_config.num_partitions = std::max<uint64_t>(
+                        1, keys_in_partition.size() / (2 * pthash::constants::min_partition_size));
+                }
+
+                if (build_config.verbose) {
+                    std::cout << "  building minimizers MPHF with " << mphf_config.num_threads
+                              << " threads and " << mphf_config.num_partitions << " partitions..."
+                              << std::endl;
+                }
+
                 mphf.build_in_internal_memory(keys_in_partition.begin(), keys_in_partition.size(),
                                               mphf_config);
+
+                mphf_config.num_partitions = 4 * mphf_config.num_threads;  // restore default value
 
                 std::cout << "  built mphs[" << partition_id << "] for " << keys_in_partition.size()
                           << " keys; bits/key = "

--- a/include/builder/build_skew_index.hpp
+++ b/include/builder/build_skew_index.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../external/pthash/include/pthash.hpp"
+#include "external/pthash/include/pthash.hpp"
 
 namespace sshash {
 

--- a/include/builder/build_skew_index.hpp
+++ b/include/builder/build_skew_index.hpp
@@ -129,7 +129,7 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
         pthash::build_configuration mphf_config;
         mphf_config.c = build_config.c;
         mphf_config.alpha = 0.94;
-        mphf_config.seed = 1234567890;  // my favourite seed
+        mphf_config.seed = util::get_seed_for_hash_function(build_config);
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
         mphf_config.num_threads = std::thread::hardware_concurrency();

--- a/include/builder/parse_file.hpp
+++ b/include/builder/parse_file.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../gz/zip_stream.hpp"
+#include "include/gz/zip_stream.hpp"
 
 namespace sshash {
 

--- a/include/builder/parse_file.hpp
+++ b/include/builder/parse_file.hpp
@@ -134,14 +134,6 @@ void parse_file(std::istream& is, parse_data& data, build_configuration const& b
         }
     };
 
-    // uint64_t less = 0;
-    // uint64_t total = 0;
-    // std::ofstream arrows("arrows.txt");
-
-    // std::vector<uint64_t> minimizers;
-
-    std::vector<uint64_t> num_minimizers_per_unitigs(100 + 1, 0);
-
     while (!is.eof()) {
         std::getline(is, sequence);  // header sequence
         if (build_config.weighted) parse_header();
@@ -166,8 +158,6 @@ void parse_file(std::istream& is, parse_data& data, build_configuration const& b
             throw std::runtime_error("file is malformed");
         }
 
-        uint64_t num_minimizers_per_unitig = 1;
-
         while (end != sequence.size() - k + 1) {
             char const* kmer = sequence.data() + end;
             assert(util::is_valid(kmer, k));
@@ -184,63 +174,16 @@ void parse_file(std::istream& is, parse_data& data, build_configuration const& b
             if (minimizer != prev_minimizer) {
                 append_super_kmer();
                 begin = end;
-                // minimizers.push_back(prev_minimizer);
-                // if (minimizer < prev_minimizer) {
-                //     // arrows << "<";
-                //     less += 1;
-                // } else {  // minimizer > prev_minimizer
-                //     // arrows << ">";
-                // }
                 prev_minimizer = minimizer;
                 glue = true;
-
-                num_minimizers_per_unitig += 1;
-                // total += 1;
             }
-            // else {
-            //     std::cerr << "=";
-            // }
 
             ++data.num_kmers;
             ++end;
         }
 
         append_super_kmer();
-
-        if (num_minimizers_per_unitig <= 16) {
-            num_minimizers_per_unitigs[num_minimizers_per_unitig] += 1;
-            // total += 1;
-        }
     }
-
-    std::cout << "k=" << k << " m=" << m << std::endl;
-    for (uint64_t i = 1; i <= 16; ++i) {
-        std::cout << "num. unitigs with " << i << " minimizers: " << num_minimizers_per_unitigs[i]
-                  << "/" << num_sequences << "("
-                  << (num_minimizers_per_unitigs[i] * 100.0) / num_sequences << "%)" << std::endl;
-    }
-
-    // std::cout << "total " << total << std::endl;
-    // std::cout << "less " << less << std::endl;
-    // std::cout << "greater " << total - less << std::endl;
-
-    // std::sort(minimizers.begin(), minimizers.end());
-    // for (auto x : minimizers) { arrows << x << '\n'; }
-    // prev_minimizer = uint64_t(-1);
-    // uint64_t count = 0;
-    // for (uint64_t i = 0; i != minimizers.size(); ++i) {
-    //     if (minimizers[i] != prev_minimizer) {
-    //         if (prev_minimizer != uint64_t(-1)) {
-    //             arrows << prev_minimizer << ' ' << count << '\n';
-    //         }
-    //         count = 1;
-    //         prev_minimizer = minimizers[i];
-    //     } else {
-    //         count += 1;
-    //     }
-    // }
-
-    // arrows.close();
 
     data.minimizers.finalize();
     builder.finalize();

--- a/include/builder/parse_file.hpp
+++ b/include/builder/parse_file.hpp
@@ -134,6 +134,14 @@ void parse_file(std::istream& is, parse_data& data, build_configuration const& b
         }
     };
 
+    // uint64_t less = 0;
+    // uint64_t total = 0;
+    // std::ofstream arrows("arrows.txt");
+
+    // std::vector<uint64_t> minimizers;
+
+    std::vector<uint64_t> num_minimizers_per_unitigs(100 + 1, 0);
+
     while (!is.eof()) {
         std::getline(is, sequence);  // header sequence
         if (build_config.weighted) parse_header();
@@ -158,6 +166,8 @@ void parse_file(std::istream& is, parse_data& data, build_configuration const& b
             throw std::runtime_error("file is malformed");
         }
 
+        uint64_t num_minimizers_per_unitig = 1;
+
         while (end != sequence.size() - k + 1) {
             char const* kmer = sequence.data() + end;
             assert(util::is_valid(kmer, k));
@@ -174,16 +184,63 @@ void parse_file(std::istream& is, parse_data& data, build_configuration const& b
             if (minimizer != prev_minimizer) {
                 append_super_kmer();
                 begin = end;
+                // minimizers.push_back(prev_minimizer);
+                // if (minimizer < prev_minimizer) {
+                //     // arrows << "<";
+                //     less += 1;
+                // } else {  // minimizer > prev_minimizer
+                //     // arrows << ">";
+                // }
                 prev_minimizer = minimizer;
                 glue = true;
+
+                num_minimizers_per_unitig += 1;
+                // total += 1;
             }
+            // else {
+            //     std::cerr << "=";
+            // }
 
             ++data.num_kmers;
             ++end;
         }
 
         append_super_kmer();
+
+        if (num_minimizers_per_unitig <= 16) {
+            num_minimizers_per_unitigs[num_minimizers_per_unitig] += 1;
+            // total += 1;
+        }
     }
+
+    std::cout << "k=" << k << " m=" << m << std::endl;
+    for (uint64_t i = 1; i <= 16; ++i) {
+        std::cout << "num. unitigs with " << i << " minimizers: " << num_minimizers_per_unitigs[i]
+                  << "/" << num_sequences << "("
+                  << (num_minimizers_per_unitigs[i] * 100.0) / num_sequences << "%)" << std::endl;
+    }
+
+    // std::cout << "total " << total << std::endl;
+    // std::cout << "less " << less << std::endl;
+    // std::cout << "greater " << total - less << std::endl;
+
+    // std::sort(minimizers.begin(), minimizers.end());
+    // for (auto x : minimizers) { arrows << x << '\n'; }
+    // prev_minimizer = uint64_t(-1);
+    // uint64_t count = 0;
+    // for (uint64_t i = 0; i != minimizers.size(); ++i) {
+    //     if (minimizers[i] != prev_minimizer) {
+    //         if (prev_minimizer != uint64_t(-1)) {
+    //             arrows << prev_minimizer << ' ' << count << '\n';
+    //         }
+    //         count = 1;
+    //         prev_minimizer = minimizers[i];
+    //     } else {
+    //         count += 1;
+    //     }
+    // }
+
+    // arrows.close();
 
     data.minimizers.finalize();
     builder.finalize();

--- a/include/builder/util.hpp
+++ b/include/builder/util.hpp
@@ -43,9 +43,7 @@ struct compact_string_pool {
             uint64_t prefix = 0;
             if (glue) {
                 prefix = k - 1;
-            } else {
-                /* otherwise, start a new piece */
-                check_contig_size();
+            } else { /* otherwise, start a new piece */
                 pieces.push_back(bvb_strings.size() / 2);
             }
             for (uint64_t i = prefix; i != size; ++i) {
@@ -58,7 +56,6 @@ struct compact_string_pool {
         void finalize() {
             /* So pieces will be of size p+1, where p is the number of DNA sequences
                in the input file. */
-            check_contig_size();
             pieces.push_back(bvb_strings.size() / 2);
             assert(pieces.front() == 0);
 
@@ -72,22 +69,6 @@ struct compact_string_pool {
         uint64_t num_super_kmers;
         std::vector<uint64_t> pieces;
         pthash::bit_vector_builder bvb_strings;
-
-    private:
-        void check_contig_size() const {
-            /* Support a max of 2^32-1 contigs, or "pieces", whose
-               max length must also be < 2^32. */
-            if (!pieces.empty()) {
-                uint64_t contig_length = bvb_strings.size() / 2 - pieces.back();
-                if (contig_length >= 1ULL << 32) {
-                    throw std::runtime_error("contig_length " + std::to_string(contig_length) +
-                                             " does not fit into 32 bits");
-                }
-                if (pieces.size() == 1ULL << 32) {
-                    throw std::runtime_error("num_contigs must be less than 2^32");
-                }
-            }
-        }
     };
 
     uint64_t num_bits() const { return strings.size(); }

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -12,9 +12,7 @@ constexpr uint64_t max_k = sizeof(kmer_t) * 4 - 1;
 /* max *odd* size that can be packed into 64 bits */
 constexpr uint64_t max_m = 31;
 
-// constexpr kmer_t invalid_uint_kmer = kmer_t(-1);
 constexpr uint64_t invalid_uint64 = uint64_t(-1);
-constexpr uint32_t invalid_uint32 = uint32_t(-1);
 
 constexpr uint64_t seed = 1;
 constexpr double c = 3.0;  // for PTHash

--- a/include/cover/cover.hpp
+++ b/include/cover/cover.hpp
@@ -5,7 +5,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "../util.hpp"
+#include "include/util.hpp"
 #include "node.hpp"
 #include "even_frequency_weights.hpp"
 

--- a/include/cover/node.hpp
+++ b/include/cover/node.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../util.hpp"
+#include "include/util.hpp"
 
 #include <vector>
 #include <deque>

--- a/include/cover/node.hpp
+++ b/include/cover/node.hpp
@@ -7,6 +7,10 @@
 
 namespace sshash {
 
+namespace constants {
+constexpr uint32_t invalid_uint32 = uint32_t(-1);
+}
+
 struct node {
     node()
         : id(constants::invalid_uint32)

--- a/include/cover/parse_file.hpp
+++ b/include/cover/parse_file.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "../../external/pthash/include/pthash.hpp"
-#include "../../external/pthash/external/cmd_line_parser/include/parser.hpp"
-#include "../../external/pthash/external/essentials/include/essentials.hpp"
-#include "../gz/zip_stream.hpp"
-#include "../gz/zip_stream.cpp"
-#include "../builder/util.hpp"
+#include "external/pthash/include/pthash.hpp"
+#include "external/pthash/external/cmd_line_parser/include/parser.hpp"
+#include "external/pthash/external/essentials/include/essentials.hpp"
+#include "include/gz/zip_stream.hpp"
+#include "include/gz/zip_stream.cpp"
+#include "include/builder/util.hpp"
 
 #include "node.hpp"
 

--- a/include/ef_sequence.hpp
+++ b/include/ef_sequence.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "../external/pthash/include/encoders/bit_vector.hpp"
-#include "../external/pthash/include/encoders/compact_vector.hpp"
-#include "../external/pthash/include/encoders/darray.hpp"
+#include "external/pthash/include/encoders/bit_vector.hpp"
+#include "external/pthash/include/encoders/compact_vector.hpp"
+#include "external/pthash/include/encoders/darray.hpp"
 
 namespace sshash {
 

--- a/include/gz/zip_stream.hpp
+++ b/include/gz/zip_stream.hpp
@@ -64,6 +64,7 @@ zran.c
 #include <ostream>
 #include <streambuf>
 #include <vector>
+#include <cstdint>
 
 //! default gzip buffer size, change this to suite your needs
 static const size_t zstream_default_buffer_size = 4096;

--- a/include/hash_util.hpp
+++ b/include/hash_util.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../external/pthash/include/pthash.hpp"
+#include "external/pthash/include/pthash.hpp"
 #include "constants.hpp"
 
 namespace sshash {

--- a/include/hash_util.hpp
+++ b/include/hash_util.hpp
@@ -53,16 +53,26 @@ typedef pthash::murmurhash2_128 minimizers_base_hasher_type;
 // typedef kmers_pthash_hasher_64 kmers_base_hasher_type;
 typedef kmers_pthash_hasher_128 kmers_base_hasher_type;
 
-typedef pthash::single_phf<minimizers_base_hasher_type,    // base hasher
-                           pthash::dictionary_dictionary,  // encoder type
-                           true                            // minimal output
-                           >
+// typedef pthash::single_phf<minimizers_base_hasher_type,    // base hasher
+//                            pthash::dictionary_dictionary,  // encoder type
+//                            true                            // minimal output
+//                            >
+//     minimizers_pthash_type;
+typedef pthash::partitioned_phf<minimizers_base_hasher_type,    // base hasher
+                                pthash::dictionary_dictionary,  // encoder type
+                                true                            // minimal output
+                                >
     minimizers_pthash_type;
 
-typedef pthash::single_phf<kmers_base_hasher_type,         // base hasher
-                           pthash::dictionary_dictionary,  // encoder type
-                           true                            // minimal output
-                           >
+// typedef pthash::single_phf<kmers_base_hasher_type,         // base hasher
+//                            pthash::dictionary_dictionary,  // encoder type
+//                            true                            // minimal output
+//                            >
+//     kmers_pthash_type;
+typedef pthash::partitioned_phf<kmers_base_hasher_type,         // base hasher
+                                pthash::dictionary_dictionary,  // encoder type
+                                true                            // minimal output
+                                >
     kmers_pthash_type;
 
 /* used to hash m-mers and determine the minimizer of a k-mer */

--- a/include/kmer.hpp
+++ b/include/kmer.hpp
@@ -2,7 +2,10 @@
 
 namespace sshash {
 
+#ifdef SSHASH_USE_MAX_KMER_LENGTH_63
+typedef __uint128_t kmer_t;
+#else
 typedef uint64_t kmer_t;
-// typedef __uint128_t kmer_t;
+#endif
 
 }  // namespace sshash

--- a/include/minimizers.hpp
+++ b/include/minimizers.hpp
@@ -10,7 +10,7 @@ struct minimizers {
         pthash::build_configuration mphf_config;
         mphf_config.c = 6.0;
         mphf_config.alpha = 0.94;
-        mphf_config.seed = 1234567890;  // my favourite seed
+        mphf_config.seed = util::get_seed_for_hash_function(build_config);
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
         mphf_config.num_threads = std::thread::hardware_concurrency();

--- a/include/minimizers.hpp
+++ b/include/minimizers.hpp
@@ -13,16 +13,21 @@ struct minimizers {
         mphf_config.seed = 1234567890;  // my favourite seed
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
-        mphf_config.num_threads = 1;
-        uint64_t num_threads = std::thread::hardware_concurrency() >= 8 ? 8 : 1;
-        if (size >= num_threads) mphf_config.num_threads = num_threads;
+        mphf_config.num_threads = std::thread::hardware_concurrency();
+        mphf_config.num_partitions = 4 * mphf_config.num_threads;
 
-        if (build_config.verbose) {
-            std::cout << "building minimizers MPHF (PTHash) with " << mphf_config.num_threads
-                      << " threads..." << std::endl;
+        if (size / mphf_config.num_partitions < pthash::constants::min_partition_size) {
+            mphf_config.num_partitions =
+                std::max<uint64_t>(1, size / (2 * pthash::constants::min_partition_size));
         }
 
-        mphf_config.ram = 2 * essentials::GB;
+        if (build_config.verbose) {
+            std::cout << "building minimizers MPHF with " << mphf_config.num_threads
+                      << " threads and " << mphf_config.num_partitions << " partitions..."
+                      << std::endl;
+        }
+
+        mphf_config.ram = 4 * essentials::GB;
         mphf_config.tmp_dir = build_config.tmp_dirname;
         m_mphf.build_in_external_memory(begin, size, mphf_config);
     }

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -114,6 +114,11 @@ struct build_configuration {
 
 namespace util {
 
+static uint64_t get_seed_for_hash_function(build_configuration const& build_config) {
+    static const uint64_t my_favourite_seed = 1234567890;
+    return build_config.seed != my_favourite_seed ? my_favourite_seed : ~my_favourite_seed;
+}
+
 /* return the position of the most significant bit */
 static inline uint32_t msb(uint32_t x) {
     assert(x > 0);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -363,8 +363,9 @@ template <typename Hasher = murmurhash2_64>
 uint64_t compute_minimizer(kmer_t kmer, const uint64_t k, const uint64_t m, const uint64_t seed) {
     assert(m <= constants::max_m);
     assert(m <= k);
+    assert(m >= (k + 2) / 2);
+    const uint64_t t = 2 * m - k - 1;
 
-    uint64_t t = (m >= (k + 2) / 2) ? (2 * m - k - 1) : (k - 2 * m + 1);
     kmer_t copy = kmer;
     const kmer_t tmer_mask = (kmer_t(1) << (2 * t)) - 1;
     const kmer_t mmer_mask = (kmer_t(1) << (2 * m)) - 1;
@@ -382,9 +383,15 @@ uint64_t compute_minimizer(kmer_t kmer, const uint64_t k, const uint64_t m, cons
     }
 
     const uint64_t w = k - m + 1;
-    if (p <= w - 1)  // same as p <= (k-t)/2, for t = 2 * m - k - 1;
-        return (copy >> (2 * p)) & mmer_mask;
 
+    /*
+        The following code is equivalent to:
+            p = p % w;
+            return (copy >> (2 * p)) & mmer_mask;
+        but it avoids the modulo.
+    */
+
+    if (p <= w - 1) return (copy >> (2 * p)) & mmer_mask;
     assert(p + t >= m);
     return (copy >> (2 * (p + t - m))) & mmer_mask;
 }

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -21,15 +21,15 @@ struct streaming_query_report {
 struct lookup_result {
     lookup_result()
         : kmer_id(constants::invalid_uint64)
-        , kmer_id_in_contig(constants::invalid_uint32)
+        , kmer_id_in_contig(constants::invalid_uint64)
         , kmer_orientation(constants::forward_orientation)
-        , contig_id(constants::invalid_uint32)
-        , contig_size(constants::invalid_uint32) {}
+        , contig_id(constants::invalid_uint64)
+        , contig_size(constants::invalid_uint64) {}
     uint64_t kmer_id;            // "absolute" kmer-id
-    uint32_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
-    uint32_t kmer_orientation;
-    uint32_t contig_id;
-    uint32_t contig_size;
+    uint64_t kmer_id_in_contig;  // "relative" kmer-id: 0 <= kmer_id_in_contig < contig_size
+    uint64_t kmer_orientation;
+    uint64_t contig_id;
+    uint64_t contig_size;
 };
 
 struct neighbourhood {

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -336,64 +336,23 @@ static inline bool is_valid(int c) { return canonicalize_basepair_forward_map[c]
 /*
     This implements the random minimizer.
 */
-// template <typename Hasher = murmurhash2_64>
-// uint64_t compute_minimizer(kmer_t kmer, const uint64_t k, const uint64_t m, const uint64_t seed)
-// {
-//     assert(m <= constants::max_m);
-//     assert(m <= k);
-//     uint64_t min_hash = uint64_t(-1);
-//     uint64_t minimizer = uint64_t(-1);
-//     kmer_t mask = (kmer_t(1) << (2 * m)) - 1;
-//     for (uint64_t i = 0; i != k - m + 1; ++i) {
-//         uint64_t mmer = static_cast<uint64_t>(kmer & mask);
-//         uint64_t hash = Hasher::hash(mmer, seed);
-//         if (hash < min_hash) {
-//             min_hash = hash;
-//             minimizer = mmer;
-//         }
-//         kmer >>= 2;
-//     }
-//     return minimizer;
-// }
-
-/*
-    This implements the LR-minimizer.
-*/
 template <typename Hasher = murmurhash2_64>
 uint64_t compute_minimizer(kmer_t kmer, const uint64_t k, const uint64_t m, const uint64_t seed) {
     assert(m <= constants::max_m);
     assert(m <= k);
-    assert(m >= (k + 2) / 2);
-    const uint64_t t = 2 * m - k - 1;
-
-    kmer_t copy = kmer;
-    const kmer_t tmer_mask = (kmer_t(1) << (2 * t)) - 1;
-    const kmer_t mmer_mask = (kmer_t(1) << (2 * m)) - 1;
-
     uint64_t min_hash = uint64_t(-1);
-    uint64_t p = 0;  // position of minimum tmer
-    for (uint64_t i = 0; i != k - t + 1; ++i) {
-        uint64_t tmer = static_cast<uint64_t>(kmer & tmer_mask);
-        uint64_t hash = Hasher::hash(tmer, seed);
+    uint64_t minimizer = uint64_t(-1);
+    kmer_t mask = (kmer_t(1) << (2 * m)) - 1;
+    for (uint64_t i = 0; i != k - m + 1; ++i) {
+        uint64_t mmer = static_cast<uint64_t>(kmer & mask);
+        uint64_t hash = Hasher::hash(mmer, seed);
         if (hash < min_hash) {
             min_hash = hash;
-            p = i;
+            minimizer = mmer;
         }
         kmer >>= 2;
     }
-
-    const uint64_t w = k - m + 1;
-
-    /*
-        The following code is equivalent to:
-            p = p % w;
-            return (copy >> (2 * p)) & mmer_mask;
-        but it avoids the modulo.
-    */
-
-    if (p <= w - 1) return (copy >> (2 * p)) & mmer_mask;
-    assert(p + t >= m);
-    return (copy >> (2 * (p + t - m))) & mmer_mask;
+    return minimizer;
 }
 
 /* used in dump.cpp */

--- a/src/check_utils.hpp
+++ b/src/check_utils.hpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>  // for std::transform
 
-#include "../include/gz/zip_stream.hpp"
+#include "include/gz/zip_stream.hpp"
 
 namespace sshash {
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../external/pthash/external/cmd_line_parser/include/parser.hpp"
-#include "../include/dictionary.hpp"
+#include "external/pthash/external/cmd_line_parser/include/parser.hpp"
+#include "include/dictionary.hpp"
 
 #include <vector>
 

--- a/src/permute.cpp
+++ b/src/permute.cpp
@@ -1,5 +1,5 @@
-#include "../include/cover/parse_file.hpp"
-#include "../include/cover/cover.hpp"
+#include "include/cover/parse_file.hpp"
+#include "include/cover/cover.hpp"
 
 using namespace sshash;
 

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -1,5 +1,5 @@
 #include "common.hpp"
-#include "../include/query/streaming_query.hpp"
+#include "include/query/streaming_query.hpp"
 
 using namespace sshash;
 

--- a/test/test_alphabet.cpp
+++ b/test/test_alphabet.cpp
@@ -1,5 +1,5 @@
-#include "../include/util.hpp"
-#include "../src/common.hpp"  // for random_kmer
+#include "include/util.hpp"
+#include "src/common.hpp"  // for random_kmer
 
 using namespace sshash;
 

--- a/test/test_alphabet.cpp
+++ b/test/test_alphabet.cpp
@@ -2,6 +2,12 @@
 
 using namespace sshash;
 
+std::ostream& operator<<(std::ostream& os, __uint128_t x) {
+    os << *(reinterpret_cast<uint64_t*>(&x) + 0);
+    os << *(reinterpret_cast<uint64_t*>(&x) + 1);
+    return os;
+}
+
 template <typename T>
 void expect(T got, T expected) {
     if (got != expected) {

--- a/test/test_alphabet.cpp
+++ b/test/test_alphabet.cpp
@@ -16,7 +16,11 @@ void expect(T got, T expected) {
     }
 }
 
-int main(int /*argc*/, char** argv) {
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cout << "Usage " << argv[0] << " k" << std::endl;
+        return 1;
+    }
     uint64_t k = std::stoull(argv[1]);
     if (k > constants::max_k) {
         std::cerr << "k must be less <= " << constants::max_k << " but got k = " << k << '\n';


### PR DESCRIPTION
This PR brings the following changes.

- The partitioned_phf type of PTHash is now the default used MPHF, rather than the single_phf which is much faster to build with no slow down at query time nor space overhead.

-  We now use 128-bit hashes by default, so that we avoid aborting due to the risk of incurring in a hash collision that could be high with 64-bit hashes.

- Several minor usability improvements.