### PR TITLE
Use universal visitors for const-ref saving

### DIFF
--- a/include/buckets.hpp
+++ b/include/buckets.hpp
@@ -256,11 +256,13 @@ struct buckets {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(pieces);
-        visitor.visit(num_super_kmers_before_bucket);
-        visitor.visit(offsets);
-        visitor.visit(strings);
+        visit_impl(visitor, *this);
     }
 
     ef_sequence<true> pieces;
@@ -269,6 +271,13 @@ struct buckets {
     pthash::bit_vector strings;
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.pieces);
+        visitor.visit(t.num_super_kmers_before_bucket);
+        visitor.visit(t.offsets);
+        visitor.visit(t.strings);
+    }
     bool is_valid(lookup_result res) const {
         return (res.contig_size != constants::invalid_uint64 and
                 res.kmer_id_in_contig < res.contig_size) and

--- a/include/dictionary.hpp
+++ b/include/dictionary.hpp
@@ -118,19 +118,29 @@ struct dictionary {
     void compute_statistics() const;
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_size);
-        visitor.visit(m_seed);
-        visitor.visit(m_k);
-        visitor.visit(m_m);
-        visitor.visit(m_canonical_parsing);
-        visitor.visit(m_minimizers);
-        visitor.visit(m_buckets);
-        visitor.visit(m_skew_index);
-        visitor.visit(m_weights);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_size);
+        visitor.visit(t.m_seed);
+        visitor.visit(t.m_k);
+        visitor.visit(t.m_m);
+        visitor.visit(t.m_canonical_parsing);
+        visitor.visit(t.m_minimizers);
+        visitor.visit(t.m_buckets);
+        visitor.visit(t.m_skew_index);
+        visitor.visit(t.m_weights);
+    }
+
     uint64_t m_size;
     uint64_t m_seed;
     uint16_t m_k;

--- a/include/ef_sequence.hpp
+++ b/include/ef_sequence.hpp
@@ -187,15 +187,24 @@ struct ef_sequence {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_universe);
-        visitor.visit(m_high_bits);
-        visitor.visit(m_high_bits_d1);
-        visitor.visit(m_high_bits_d0);
-        visitor.visit(m_low_bits);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_universe);
+        visitor.visit(t.m_high_bits);
+        visitor.visit(t.m_high_bits_d1);
+        visitor.visit(t.m_high_bits_d0);
+        visitor.visit(t.m_low_bits);
+    }
     uint64_t m_universe;
     pthash::bit_vector m_high_bits;
     pthash::darray1 m_high_bits_d1;

--- a/include/minimizers.hpp
+++ b/include/minimizers.hpp
@@ -41,6 +41,11 @@ struct minimizers {
     uint64_t num_bits() const { return m_mphf.num_bits(); }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visitor.visit(m_mphf);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
         visitor.visit(m_mphf);
     }

--- a/include/skew_index.hpp
+++ b/include/skew_index.hpp
@@ -45,12 +45,13 @@ struct skew_index {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(min_log2);
-        visitor.visit(max_log2);
-        visitor.visit(log2_max_num_super_kmers_in_bucket);
-        visitor.visit(mphfs);
-        visitor.visit(positions);
+        visit_impl(visitor, *this);
     }
 
     uint16_t min_log2;
@@ -58,6 +59,16 @@ struct skew_index {
     uint32_t log2_max_num_super_kmers_in_bucket;
     std::vector<kmers_pthash_type> mphfs;
     std::vector<pthash::compact_vector> positions;
+
+private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.min_log2);
+        visitor.visit(t.max_log2);
+        visitor.visit(t.log2_max_num_super_kmers_in_bucket);
+        visitor.visit(t.mphfs);
+        visitor.visit(t.positions);
+    }
 };
 
 }  // namespace sshash

--- a/include/weights.hpp
+++ b/include/weights.hpp
@@ -169,13 +169,23 @@ struct weights {
     }
 
     template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
+
+    template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_weight_interval_values);
-        visitor.visit(m_weight_interval_lengths);
-        visitor.visit(m_weight_dictionary);
+        visit_impl(visitor, *this);
     }
 
 private:
+    template <typename Visitor, typename T>
+    static void visit_impl(Visitor& visitor, T&& t) {
+        visitor.visit(t.m_weight_interval_values);
+        visitor.visit(t.m_weight_interval_lengths);
+        visitor.visit(t.m_weight_dictionary);
+    }
+
     pthash::compact_vector m_weight_interval_values;
     ef_sequence<true> m_weight_interval_lengths;
     pthash::compact_vector m_weight_dictionary;


### PR DESCRIPTION
See https://github.com/jermp/pthash/pull/65 and https://github.com/jermp/essentials/pull/9. If those two are merged, the changes would also need to be propagated to sshash. This will allow to use const-ref instead of simple ref for saving, which is good and important for third-party users.

**Note**: Submodule pthash needs to be updated in the PR before actually merging this change.