### PR TITLE
Submodule integration for piscem

### DIFF
--- a/include/builder/build_skew_index.hpp
+++ b/include/builder/build_skew_index.hpp
@@ -123,7 +123,7 @@ void build_skew_index(skew_index& m_skew_index, parse_data& data, buckets const&
         mphf_config.seed = util::get_seed_for_hash_function(build_config);
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
-        mphf_config.num_threads = std::thread::hardware_concurrency();
+        mphf_config.num_threads = build_config.num_threads;
         mphf_config.num_partitions = 4 * mphf_config.num_threads;
 
         uint64_t partition_id = 0;

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -12,6 +12,8 @@ constexpr uint64_t max_k = sizeof(kmer_t) * 4 - 1;
 /* max *odd* size that can be packed into 64 bits */
 constexpr uint64_t max_m = 31;
 
+constexpr uint64_t threads = 16;
+
 constexpr uint64_t invalid_uint64 = uint64_t(-1);
 
 constexpr uint64_t seed = 1;

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -12,8 +12,6 @@ constexpr uint64_t max_k = sizeof(kmer_t) * 4 - 1;
 /* max *odd* size that can be packed into 64 bits */
 constexpr uint64_t max_m = 31;
 
-constexpr uint64_t threads = 16;
-
 constexpr uint64_t invalid_uint64 = uint64_t(-1);
 
 constexpr uint64_t seed = 1;

--- a/include/minimizers.hpp
+++ b/include/minimizers.hpp
@@ -13,7 +13,7 @@ struct minimizers {
         mphf_config.seed = util::get_seed_for_hash_function(build_config);
         mphf_config.minimal_output = true;
         mphf_config.verbose_output = false;
-        mphf_config.num_threads = std::thread::hardware_concurrency();
+        mphf_config.num_threads = build_config.num_threads;
         mphf_config.num_partitions = 4 * mphf_config.num_threads;
 
         if (size / mphf_config.num_partitions < pthash::constants::min_partition_size) {

--- a/include/query/streaming_query_canonical_parsing.hpp
+++ b/include/query/streaming_query_canonical_parsing.hpp
@@ -43,6 +43,24 @@ struct streaming_query_canonical_parsing {
         m_minimizer_not_found = false;
     }
 
+    inline void reset_state() {
+        // reset all of the relevant state
+        m_minimizer_not_found = false;
+        start();
+        m_curr_minimizer = constants::invalid_uint64;
+        m_prev_minimizer = constants::invalid_uint64;
+        m_kmer = constants::invalid_uint64;
+
+        m_string_iterator.at(0);
+        m_begin = 0;
+        m_end = 0;
+        m_pos_in_window = 0;
+        m_window_size = 0;
+
+        m_res.kmer_id = constants::invalid_uint64;
+        m_reverse = false;
+    }
+
     lookup_result lookup_advanced(const char* kmer) {
         /* 1. validation */
         bool is_valid = m_start ? util::is_valid(kmer, m_k) : util::is_valid(kmer[m_k - 1]);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -86,13 +86,15 @@ struct build_configuration {
 
         , l(constants::min_l)
         , c(constants::c)
+        
+        , num_threads(1)
 
         , canonical_parsing(false)
         , weighted(false)
         , verbose(true)
 
         , tmp_dirname(constants::default_tmp_dirname)
-        , input_type(input_build_type::fasta) {}
+        , input_type(input_build_type::cfseg) {}
         
 
     uint64_t k;  // kmer size
@@ -101,6 +103,8 @@ struct build_configuration {
 
     uint64_t l;  // drive dictionary trade-off
     double c;    // drive PTHash trade-off
+
+    uint64_t num_threads;
 
     bool canonical_parsing;
     bool weighted;

--- a/src/build.cpp
+++ b/src/build.cpp
@@ -14,11 +14,14 @@ int build(int argc, char** argv) {
     parser.add("k", "K-mer length (must be <= " + std::to_string(constants::max_k) + ").", "-k",
                true);
     parser.add("m", "Minimizer length (must be < k).", "-m", true);
-    parser.add("f", "Format of input (must be fasta | cfseg).", "-f", false);
 
     /* Optional arguments. */
+    parser.add("f", "Format of input (must be fasta | cfseg).", "-f", false);
     parser.add("seed",
                "Seed for construction (default is " + std::to_string(constants::seed) + ").", "-s",
+               false);
+    parser.add("t",
+               "Number of threads (default is " + std::to_string(constants::threads) + ").", "-t",
                false);
     parser.add("l",
                "A (integer) constant that controls the space/time trade-off of the dictionary. "
@@ -76,6 +79,7 @@ int build(int argc, char** argv) {
     }
 
     if (parser.parsed("seed")) build_config.seed = parser.get<uint64_t>("seed");
+    if (parser.parsed("t")) build_config.num_threads = parser.get<uint64_t>("t");
     if (parser.parsed("l")) build_config.l = parser.get<double>("l");
     if (parser.parsed("c")) build_config.c = parser.get<double>("c");
     build_config.canonical_parsing = parser.get<bool>("canonical_parsing");

--- a/src/build.cpp
+++ b/src/build.cpp
@@ -20,8 +20,10 @@ int build(int argc, char** argv) {
     parser.add("seed",
                "Seed for construction (default is " + std::to_string(constants::seed) + ").", "-s",
                false);
+    uint64_t threads = std::max(std::min(static_cast<uint64_t>(16),
+        static_cast<uint64_t>(std::thread::hardware_concurrency())), static_cast<uint64_t>(2));
     parser.add("t",
-               "Number of threads (default is " + std::to_string(constants::threads) + ").", "-t",
+               "Number of threads (default is " + std::to_string(threads) + ").", "-t",
                false);
     parser.add("l",
                "A (integer) constant that controls the space/time trade-off of the dictionary. "


### PR DESCRIPTION
added threads as a command line argument. Also added function `reset_state` under `streaming_query_canonical_parsing`. We have currently integrated the branch with piscem-cpp.

Feature requests
- verbose option that suppresses writing output to stdout
- merge this branch (`submodule-integration-for-piscem`) with master.