### PR TITLE
make static function inline in header

### DIFF
--- a/include/util.hpp
+++ b/include/util.hpp
@@ -118,7 +118,7 @@ struct build_configuration {
 
 namespace util {
 
-static uint64_t get_seed_for_hash_function(build_configuration const& build_config) {
+static inline uint64_t get_seed_for_hash_function(build_configuration const& build_config) {
     static const uint64_t my_favourite_seed = 1234567890;
     return build_config.seed != my_favourite_seed ? my_favourite_seed : ~my_favourite_seed;
 }


### PR DESCRIPTION
Clang warns:

```
util.hpp:127:17: warning: 'static' function 'get_seed_for_hash_function' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
  static uint64_t get_seed_for_hash_function(build_configuration const& build_config) {
```

I think this could cause potential issues across translation units and so it's probably best to inline this?